### PR TITLE
Switch to OAuth2 Proxy for authentication

### DIFF
--- a/roles/caddy/defaults/main.yml
+++ b/roles/caddy/defaults/main.yml
@@ -2,3 +2,4 @@
 caddy_version: v2.4.6
 caddy_home_dir: /var/www
 caddy_file: Caddyfile
+caddy_site_address: http://localhost:8080

--- a/roles/caddy/files/Caddyfile
+++ b/roles/caddy/files/Caddyfile
@@ -1,1 +1,0 @@
-http://localhost:8080

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -46,8 +46,8 @@
   notify: restart caddy
 
 - name: install caddyfile
-  copy:
-    src: "{{ caddy_file }}"
+  template:
+    src: Caddyfile
     dest: /etc/caddy/Caddyfile
     owner: www-data
     group: www-data

--- a/roles/caddy/templates/Caddyfile
+++ b/roles/caddy/templates/Caddyfile
@@ -1,0 +1,9 @@
+{{ caddy_site_address }} {
+	encode gzip
+
+	log {
+		output stdout
+	}
+
+	reverse_proxy /* 127.0.0.1:4180
+}

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -1,15 +1,10 @@
 ---
-grafana_version: 8.2.6
+grafana_version: 8.3.2
 grafana_home_dir: "/var/lib/grafana"
 grafana_config_dir: "/etc/grafana"
 grafana_config_path: "{{ grafana_config_dir }}/defaults.ini"
 grafana_web_external_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"
 grafana_admin_user: "admin"
 grafana_cookie_secure: true
-grafana_github_client_id: ""
-grafana_github_client_secret: ""
-grafana_auth_github_organizations: ""
-grafana_metrics_basic_auth_username: ""
-grafana_metrics_basic_auth_password: ""
 grafana_dashboards_dir: ""
 grafana_auto_assign_org_role: "Editor"

--- a/roles/grafana/templates/defaults.ini
+++ b/roles/grafana/templates/defaults.ini
@@ -28,7 +28,7 @@ provisioning = "{{ grafana_config_dir }}/conf/provisioning"
 
 #################################### Server ##############################
 [server]
-# Protocol (http, https, socket)
+# Protocol (http, https, h2, socket)
 protocol = http
 
 # The ip address to bind to, empty will bind to all interfaces
@@ -46,6 +46,8 @@ enforce_domain = false
 
 # The full public facing url
 root_url = {{ grafana_web_external_url }}
+
+# Serve Grafana from subpath specified in `root_url` setting. By default it is set to `false` for compatibility reasons.
 serve_from_sub_path = true
 
 # Log web requests
@@ -63,6 +65,13 @@ cert_key =
 
 # Unix socket path
 socket = /tmp/grafana.sock
+
+# CDN Url
+cdn_url =
+
+# Sets the maximum time in minutes before timing out read of an incoming request and closing idle connections.
+# `0` means there is no timeout for reading the request.
+read_timeout = 0
 
 #################################### Database ############################
 [database]
@@ -96,6 +105,12 @@ log_queries =
 # For "mysql", use either "true", "false", or "skip-verify".
 ssl_mode = disable
 
+# Database drivers may support different transaction isolation levels.
+# Currently, only "mysql" driver supports isolation levels.
+# If the value is empty - driver's default isolation level is applied.
+# For "mysql" use "READ-UNCOMMITTED", "READ-COMMITTED", "REPEATABLE-READ" or "SERIALIZABLE".
+isolation_level =
+
 ca_cert_path =
 client_key_path =
 client_cert_path =
@@ -114,7 +129,7 @@ type = database
 
 # cache connectionstring options
 # database: will use Grafana primary database.
-# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
+# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=0,ssl=false`. Only addr is required. ssl may be 'true', 'false', or 'insecure'.
 # memcache: 127.0.0.1:11211
 connstr =
 
@@ -124,11 +139,44 @@ connstr =
 # This enables data proxy logging, default is false
 logging = false
 
-# How long the data proxy should wait before timing out default is 30 (seconds)
+# How long the data proxy waits to read the headers of the response before timing out, default is 30 seconds.
+# This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 timeout = 30
 
-# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
+# How long the data proxy waits to establish a TCP connection before timing out, default is 10 seconds.
+dialTimeout = 10
+
+# How many seconds the data proxy waits before sending a keepalive request.
+keep_alive_seconds = 30
+
+# How many seconds the data proxy waits for a successful TLS Handshake before timing out.
+tls_handshake_timeout_seconds = 10
+
+# How many seconds the data proxy will wait for a server's first response headers after
+# fully writing the request headers if the request has an "Expect: 100-continue"
+# header. A value of 0 will result in the body being sent immediately, without
+# waiting for the server to approve.
+expect_continue_timeout_seconds = 1
+
+# Optionally limits the total number of connections per host, including connections in the dialing,
+# active, and idle states. On limit violation, dials will block.
+# A value of zero (0) means no limit.
+max_conns_per_host = 0
+
+# The maximum number of idle connections that Grafana will keep alive.
+max_idle_connections = 100
+
+# How many seconds the data proxy keeps an idle connection open before timing out.
+idle_conn_timeout_seconds = 90
+
+# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request.
 send_user_header = false
+
+# Limit the amount of bytes that will be read/accepted from responses of outgoing HTTP requests.
+response_limit = 0
+
+# Limits the number of rows that Grafana will process from SQL data sources.
+row_limit = 1000000
 
 #################################### Analytics ###########################
 [analytics]
@@ -136,7 +184,10 @@ send_user_header = false
 # No ip addresses are being tracked, only simple counters to track
 # running instances, dashboard and error counts. It is very helpful to us.
 # Change this option to false to disable reporting.
-reporting_enabled = true
+reporting_enabled = false
+
+# The name of the distributor of the Grafana instance. Ex hosted-grafana, grafana-labs
+reporting_distributor = grafana-labs
 
 # Set to false to disable all checks to https://grafana.com
 # for new versions (grafana itself and plugins), check is used
@@ -151,8 +202,23 @@ google_analytics_ua_id =
 # Google Tag Manager ID, only enabled if you specify an id here
 google_tag_manager_id =
 
+# Rudderstack write key, enabled only if rudderstack_data_plane_url is also set
+rudderstack_write_key =
+
+# Rudderstack data plane url, enabled only if rudderstack_write_key is also set
+rudderstack_data_plane_url =
+
+# Application Insights connection string. Specify an URL string to enable this feature.
+application_insights_connection_string =
+
+# Optional. Specifies an Application Insights endpoint URL where the endpoint string is wrapped in backticks ``.
+application_insights_endpoint_url =
+
 #################################### Security ############################
 [security]
+# disable creation of admin user on first start of grafana
+disable_initial_admin_creation = false
+
 # default admin user, created on startup
 admin_user = {{ grafana_admin_user }}
 
@@ -174,11 +240,43 @@ disable_brute_force_login_protection = false
 # set to true if you host Grafana behind HTTPS. default is false.
 cookie_secure = {{ grafana_cookie_secure }}
 
-# set cookie SameSite attribute. defaults to `lax`. can be set to "lax", "strict" and "none"
+# set cookie SameSite attribute. defaults to `lax`. can be set to "lax", "strict", "none" and "disabled"
 cookie_samesite = lax
 
 # set to true if you want to allow browsers to render Grafana in a <frame>, <iframe>, <embed> or <object>. default is false.
 allow_embedding = false
+
+# Set to true if you want to enable http strict transport security (HSTS) response header.
+# This is only sent when HTTPS is enabled in this configuration.
+# HSTS tells browsers that the site should only be accessed using HTTPS.
+strict_transport_security = false
+
+# Sets how long a browser should cache HSTS. Only applied if strict_transport_security is enabled.
+strict_transport_security_max_age_seconds = 86400
+
+# Set to true if to enable HSTS preloading option. Only applied if strict_transport_security is enabled.
+strict_transport_security_preload = false
+
+# Set to true if to enable the HSTS includeSubDomains option. Only applied if strict_transport_security is enabled.
+strict_transport_security_subdomains = false
+
+# Set to true to enable the X-Content-Type-Options response header.
+# The X-Content-Type-Options response HTTP header is a marker used by the server to indicate that the MIME types advertised
+# in the Content-Type headers should not be changed and be followed.
+x_content_type_options = true
+
+# Set to true to enable the X-XSS-Protection header, which tells browsers to stop pages from loading
+# when they detect reflected cross-site scripting (XSS) attacks.
+x_xss_protection = true
+
+# Enable adding the Content-Security-Policy header to your requests.
+# CSP allows to control resources the user agent is allowed to load and helps prevent XSS attacks.
+content_security_policy = false
+
+# Set Content Security Policy template used when adding the Content-Security-Policy header to your requests.
+# $NONCE in the template includes a random nonce.
+# $ROOT_PATH is server.root_url without the protocol.
+content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
 
 #################################### Snapshots ###########################
 [snapshots]
@@ -186,6 +284,10 @@ allow_embedding = false
 external_enabled = true
 external_snapshot_url = https://snapshots-origin.raintank.io
 external_snapshot_name = Publish to snapshot.raintank.io
+
+# Set to true to enable this Grafana instance act as an external snapshot server and allow unauthenticated requests for
+# creating and deleting snapshots.
+public_mode = false
 
 # remove expired snapshot
 snapshot_remove_expired = true
@@ -195,6 +297,18 @@ snapshot_remove_expired = true
 [dashboards]
 # Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
 versions_to_keep = 20
+
+# Minimum dashboard refresh interval. When set, this will restrict users to set the refresh interval of a dashboard lower than given interval. Per default this is 5 seconds.
+# The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
+min_refresh_interval = 5s
+
+# Path to the default home dashboard. If this value is empty, then Grafana uses StaticRootPath + "dashboards/home.json"
+default_home_dashboard_path =
+
+################################### Data sources #########################
+[datasources]
+# Upper limit of data sources that Grafana will return. This limit is a temporary configuration and it will be deprecated when pagination will be introduced on the list data sources API.
+datasource_limit = 5000
 
 #################################### Users ###############################
 [users]
@@ -223,6 +337,9 @@ password_hint = password
 # Default UI theme ("dark" or "light")
 default_theme = dark
 
+# Path to a custom home page. Users are only redirected to this if the default home dashboard is used. It should match a frontend route and contain a leading slash.
+home_page =
+
 # External user management
 external_manage_link_url =
 external_manage_link_name =
@@ -234,15 +351,21 @@ viewers_can_edit = false
 # Editors can administrate dashboard, folders and teams they create
 editors_can_admin = false
 
+# The duration in time a user invitation remains valid before expiring. This setting should be expressed as a duration. Examples: 6h (hours), 2d (days), 1w (week). Default is 24h (24 hours). The minimum supported duration is 15m (15 minutes).
+user_invite_max_lifetime_duration = 24h
+
+# Enter a comma-separated list of usernames to hide them in the Grafana UI. These users are shown to Grafana admins and to themselves.
+hidden_users =
+
 [auth]
 # Login cookie name
 login_cookie_name = grafana_session
 
-# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days.
-login_maximum_inactive_lifetime_days = 7
+# The maximum lifetime (duration) an authenticated user can be inactive before being required to login at next visit. Default is 7 days (7d). This setting should be expressed as a duration, e.g. 5m (minutes), 6h (hours), 10d (days), 2w (weeks), 1M (month). The lifetime resets at each successful token rotation (token_rotation_interval_minutes).
+login_maximum_inactive_lifetime_duration =
 
-# The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
-login_maximum_lifetime_days = 30
+# The maximum lifetime (duration) an authenticated user can be logged in since login time before being required to login. Default is 30 days (30d). This setting should be expressed as a duration, e.g. 5m (minutes), 6h (hours), 10d (days), 2w (weeks), 1M (month).
+login_maximum_lifetime_duration =
 
 # How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
 token_rotation_interval_minutes = 10
@@ -250,8 +373,8 @@ token_rotation_interval_minutes = 10
 # Set to true to disable (hide) the login form, useful if you use OAuth
 disable_login_form = true
 
-# Set to true to disable the signout link in the side menu. useful if you use auth.proxy
-disable_signout_menu = true
+# Set to true to disable the sign out link in the side menu. Useful if you use auth.proxy or auth.jwt.
+disable_signout_menu = false
 
 # URL to redirect the user to after sign out
 signout_redirect_url =
@@ -259,6 +382,15 @@ signout_redirect_url =
 # Set to true to attempt login with OAuth automatically, skipping the login screen.
 # This setting is ignored if multiple OAuth providers are configured.
 oauth_auto_login = true
+
+# OAuth state max age cookie duration in seconds. Defaults to 600 seconds.
+oauth_state_cookie_max_age = 600
+
+# limit of api_key seconds to live before expiration
+api_key_max_seconds_to_live = -1
+
+# Set to true to enable SigV4 authentication option for HTTP-based datasources
+sigv4_auth_enabled = false
 
 #################################### Anonymous Auth ######################
 [auth.anonymous]
@@ -271,29 +403,34 @@ org_name = Main Org.
 # specify role for unauthenticated users
 org_role = Viewer
 
-#################################### Github Auth #########################
+# mask the Grafana version number for unauthenticated users
+hide_version = false
+
+#################################### GitHub Auth #########################
 [auth.github]
-enabled = true
+enabled = false
 allow_sign_up = true
-client_id = {{ grafana_auth_github_client_id }}
-client_secret = {{ grafana_auth_github_client_secret }}
+client_id = some_id
+client_secret =
 scopes = user:email,read:org
 auth_url = https://github.com/login/oauth/authorize
 token_url = https://github.com/login/oauth/access_token
 api_url = https://api.github.com/user
-# team_ids =
-allowed_organizations = {{ grafana_auth_github_organizations }}
+allowed_domains =
+team_ids =
+allowed_organizations =
 
 #################################### GitLab Auth #########################
 [auth.gitlab]
 enabled = false
 allow_sign_up = true
 client_id = some_id
-client_secret = some_secret
+client_secret =
 scopes = api
 auth_url = https://gitlab.com/oauth/authorize
 token_url = https://gitlab.com/oauth/token
 api_url = https://gitlab.com/api/v4
+allowed_domains =
 allowed_groups =
 
 #################################### Google Auth #########################
@@ -301,7 +438,7 @@ allowed_groups =
 enabled = false
 allow_sign_up = true
 client_id = some_client_id
-client_secret = some_client_secret
+client_secret =
 scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
 auth_url = https://accounts.google.com/o/oauth2/auth
 token_url = https://accounts.google.com/o/oauth2/token
@@ -315,7 +452,7 @@ hosted_domain =
 enabled = false
 allow_sign_up = true
 client_id = some_id
-client_secret = some_secret
+client_secret =
 scopes = user:email
 allowed_organizations =
 
@@ -323,9 +460,38 @@ allowed_organizations =
 enabled = false
 allow_sign_up = true
 client_id = some_id
-client_secret = some_secret
+client_secret =
 scopes = user:email
 allowed_organizations =
+
+#################################### Azure AD OAuth #######################
+[auth.azuread]
+name = Azure AD
+enabled = false
+allow_sign_up = true
+client_id = some_client_id
+client_secret =
+scopes = openid email profile
+auth_url = https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize
+token_url = https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token
+allowed_domains =
+allowed_groups =
+
+#################################### Okta OAuth #######################
+[auth.okta]
+name = Okta
+enabled = false
+allow_sign_up = true
+client_id = some_id
+client_secret =
+scopes = openid profile email groups
+auth_url = https://<tenant-id>.okta.com/oauth2/v1/authorize
+token_url = https://<tenant-id>.okta.com/oauth2/v1/token
+api_url = https://<tenant-id>.okta.com/oauth2/v1/userinfo
+allowed_domains =
+allowed_groups =
+role_attribute_path =
+role_attribute_strict = false
 
 #################################### Generic OAuth #######################
 [auth.generic_oauth]
@@ -333,33 +499,58 @@ name = OAuth
 enabled = false
 allow_sign_up = true
 client_id = some_id
-client_secret = some_secret
+client_secret =
 scopes = user:email
+empty_scopes = false
 email_attribute_name = email:primary
+email_attribute_path =
+login_attribute_path =
+name_attribute_path =
+role_attribute_path =
+role_attribute_strict = false
+groups_attribute_path =
+id_token_attribute_name =
+team_ids_attribute_path =
 auth_url =
 token_url =
 api_url =
+teams_url =
+allowed_domains =
 team_ids =
 allowed_organizations =
 tls_skip_verify_insecure = false
 tls_client_cert =
 tls_client_key =
 tls_client_ca =
-send_client_credentials_via_post = false
 
 #################################### Basic Auth ##########################
 [auth.basic]
-enabled = false
+enabled = true
 
 #################################### Auth Proxy ##########################
 [auth.proxy]
-enabled = false
-header_name = X-WEBAUTH-USER
+enabled = true
+header_name = X-Forwarded-User
 header_property = username
 auto_sign_up = true
+# Deprecated, use sync_ttl instead
 ldap_sync_ttl = 60
+sync_ttl = 60
 whitelist =
 headers =
+enable_login_token = false
+
+#################################### Auth JWT ##########################
+[auth.jwt]
+enabled = false
+header_name =
+email_claim =
+username_claim =
+jwk_set_url =
+jwk_set_file =
+cache_ttl = 60m
+expected_claims = {}
+key_file =
 
 #################################### Auth LDAP ###########################
 [auth.ldap]
@@ -367,9 +558,39 @@ enabled = false
 config_file = /etc/grafana/ldap.toml
 allow_sign_up = true
 
-# LDAP backround sync (Enterprise only)
-sync_cron = @hourly
-active_sync_enabled = false
+# LDAP background sync (Enterprise only)
+# At 1 am every day
+sync_cron = "0 0 1 * * *"
+active_sync_enabled = true
+
+#################################### AWS ###########################
+[aws]
+# Enter a comma-separated list of allowed AWS authentication providers.
+# Options are: default (AWS SDK Default), keys (Access && secret key), credentials (Credentials field), ec2_iam_role (EC2 IAM Role)
+allowed_auth_providers = default,keys,credentials
+
+# Allow AWS users to assume a role using temporary security credentials.
+# If true, assume role will be enabled for all AWS authentication providers that are specified in aws_auth_providers
+assume_role_enabled = true
+
+# Specify max no of pages to be returned by the ListMetricPages API
+list_metrics_page_limit = 500
+
+#################################### Azure ###############################
+[azure]
+# Azure cloud environment where Grafana is hosted
+# Possible values are AzureCloud, AzureChinaCloud, AzureUSGovernment and AzureGermanCloud
+# Default value is AzureCloud (i.e. public cloud)
+cloud = AzureCloud
+
+# Specifies whether Grafana hosted in Azure service with Managed Identity configured (e.g. Azure Virtual Machines instance)
+# If enabled, the managed identity can be used for authentication of Grafana in Azure services
+# Disabled by default, needs to be explicitly enabled
+managed_identity_enabled = false
+
+# Client ID to use for user-assigned managed identity
+# Should be set for user-assigned identity and should be empty for system-assigned identity
+managed_identity_client_id =
 
 #################################### SMTP / Emailing #####################
 [smtp]
@@ -384,10 +605,12 @@ skip_verify = false
 from_address = admin@grafana.localhost
 from_name = Grafana
 ehlo_identity =
+startTLS_policy =
 
 [emails]
 welcome_email_on_sign_up = false
-templates_pattern = emails/*.html
+templates_pattern = emails/*.html, emails/*.txt
+content_types = text/html
 
 #################################### Logging ##########################
 [log]
@@ -446,6 +669,25 @@ facility =
 # Syslog tag. By default, the process' argv[0] is used.
 tag =
 
+[log.frontend]
+# Should Sentry javascript agent be initialized
+enabled = false
+
+# Sentry DSN if you want to send events to Sentry.
+sentry_dsn =
+
+# Custom HTTP endpoint to send events captured by the Sentry agent to. Default will log the events to stdout.
+custom_endpoint = /log
+
+# Rate of events to be reported between 0 (none) and 1 (all), float
+sample_rate = 1.0
+
+# Requests per second limit enforced per an extended period, for Grafana backend log ingestion endpoint (/log).
+log_endpoint_requests_per_second_limit = 3
+
+# Max requests accepted per short interval of time for Grafana backend log ingestion endpoint (/log)
+log_endpoint_burst_limit = 15
+
 #################################### Usage Quotas ########################
 [quota]
 enabled = false
@@ -462,6 +704,9 @@ org_data_source = 10
 
 # limit number of api_keys per Org.
 org_api_key = 10
+
+# limit number of alerts per Org.
+org_alert_rule = 100
 
 # limit number of orgs a user can create.
 user_org = 10
@@ -481,11 +726,70 @@ global_api_key = -1
 # global limit on number of logged in users.
 global_session = -1
 
+# global limit of alerts
+global_alert_rule = -1
+
+#################################### Unified Alerting ####################
+[unified_alerting]
+# Enable the Unified Alerting sub-system and interface. When enabled we'll migrate all of your alert rules and notification channels to the new system. New alert rules will be created and your notification channels will be converted into an Alertmanager configuration. Previous data is preserved to enable backwards compatibility but new data is removed.
+enabled = false
+
+# Comma-separated list of organization IDs for which to disable unified alerting. Only supported if unified alerting is enabled.
+disabled_orgs =
+
+# Specify the frequency of polling for admin config changes.
+# The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
+admin_config_poll_interval = 60s
+
+# Specify the frequency of polling for Alertmanager config changes.
+# The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
+alertmanager_config_poll_interval = 60s
+
+# Listen address/hostname and port to receive unified alerting messages for other Grafana instances. The port is used for both TCP and UDP. It is assumed other Grafana instances are also running on the same port.
+ha_listen_address = "0.0.0.0:9094"
+
+# Explicit address/hostname and port to advertise other Grafana instances. The port is used for both TCP and UDP.
+ha_advertise_address = ""
+
+# Comma-separated list of initial instances (in a format of host:port) that will form the HA cluster. Configuring this setting will enable High Availability mode for alerting.
+ha_peers = ""
+
+# Time to wait for an instance to send a notification via the Alertmanager. In HA, each Grafana instance will
+# be assigned a position (e.g. 0, 1). We then multiply this position with the timeout to indicate how long should
+# each instance wait before sending the notification to take into account replication lag.
+# The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
+ha_peer_timeout = 15s
+
+# The interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated
+# across cluster more quickly at the expense of increased bandwidth usage.
+# The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
+ha_gossip_interval = 200ms
+
+# The interval between gossip full state syncs. Setting this interval lower (more frequent) will increase convergence speeds
+# across larger clusters at the expense of increased bandwidth usage.
+# The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
+ha_push_pull_interval = 60s
+
+# Enable or disable alerting rule execution. The alerting UI remains visible. This option has a legacy version in the `[alerting]` section that takes precedence.
+execute_alerts = true
+
+# Alert evaluation timeout when fetching data from the datasource. This option has a legacy version in the `[alerting]` section that takes precedence.
+# The timeout string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
+evaluation_timeout = 30s
+
+# Number of times we'll attempt to evaluate an alert rule before giving up on that evaluation. This option has a legacy version in the `[alerting]` section that takes precedence.
+max_attempts = 3
+
+# Minimum interval to enforce between rule evaluations. Rules will be adjusted if they are less than this value or if they are not multiple of the scheduler interval (10s). Higher values can help with resource management as we'll schedule fewer evaluations over time. This option has a legacy version in the `[alerting]` section that takes precedence.
+# The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
+min_interval = 10s
+
 #################################### Alerting ############################
 [alerting]
-# Disable alerting engine & UI features
+# Disable legacy alerting engine & UI features
 enabled = true
-# Makes it possible to turn off alert rule execution but alerting UI is visible
+
+# Makes it possible to turn off alert execution but alerting UI is visible
 execute_alerts = true
 
 # Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
@@ -507,6 +811,41 @@ notification_timeout_seconds = 30
 # Default setting for max attempts to sending alert notifications. Default value is 3
 max_attempts = 3
 
+# Makes it possible to enforce a minimal interval between evaluations, to reduce load on the backend
+min_interval_seconds = 1
+
+# Configures for how long alert annotations are stored. Default is 0, which keeps them forever.
+# This setting should be expressed as an duration. Ex 6h (hours), 10d (days), 2w (weeks), 1M (month).
+max_annotation_age =
+
+# Configures max number of alert annotations that Grafana stores. Default value is 0, which keeps all alert annotations.
+max_annotations_to_keep =
+
+#################################### Annotations #########################
+[annotations]
+# Configures the batch size for the annotation clean-up job. This setting is used for dashboard, API, and alert annotations.
+cleanupjob_batchsize = 100
+
+[annotations.dashboard]
+# Dashboard annotations means that annotations are associated with the dashboard they are created on.
+
+# Configures how long dashboard annotations are stored. Default is 0, which keeps them forever.
+# This setting should be expressed as a duration. Examples: 6h (hours), 10d (days), 2w (weeks), 1M (month).
+max_age =
+
+# Configures max number of dashboard annotations that Grafana stores. Default value is 0, which keeps all dashboard annotations.
+max_annotations_to_keep =
+
+[annotations.api]
+# API annotations means that the annotations have been created using the API without any
+# association with a dashboard.
+
+# Configures how long Grafana stores API annotations. Default is 0, which keeps them forever.
+# This setting should be expressed as a duration. Examples: 6h (hours), 10d (days), 2w (weeks), 1M (month).
+max_age =
+
+# Configures max number of API annotations that Grafana keeps. Default value is 0, which keeps all API annotations.
+max_annotations_to_keep =
 
 #################################### Explore #############################
 [explore]
@@ -516,12 +855,20 @@ enabled = true
 #################################### Internal Grafana Metrics ############
 # Metrics available at HTTP API Url /metrics
 [metrics]
-enabled           = true
-interval_seconds  = 10
+enabled              = true
+interval_seconds     = 10
+# Disable total stats (stat_totals_*) metrics to be generated
+disable_total_stats = false
 
 #If both are set, basic auth will be required for the metrics endpoint.
-basic_auth_username = {{ grafana_metrics_basic_auth_username }}
-basic_auth_password = {{ grafana_metrics_basic_auth_password }}
+basic_auth_username =
+basic_auth_password =
+
+# Metrics environment info adds dimensions to the `grafana_environment_info` metric, which
+# can expose more information about the Grafana instance.
+[metrics.environment_info]
+#exampleLabel1 = exampleValue1
+#exampleLabel2 = exampleValue2
 
 # Send internal Grafana metrics to graphite
 [metrics.graphite]
@@ -529,6 +876,7 @@ basic_auth_password = {{ grafana_metrics_basic_auth_password }}
 address =
 prefix = prod.grafana.%(instance_name)s.
 
+#################################### Grafana.com integration  ##########################
 [grafana_net]
 url = https://grafana.com
 
@@ -551,13 +899,23 @@ sampler_type = const
 # and indicates the initial sampling rate before the actual one
 # is received from the mothership
 sampler_param = 1
+# sampling_server_url is the URL of a sampling manager providing a sampling strategy.
+sampling_server_url =
+# Whether or not to use Zipkin span propagation (x-b3- HTTP headers).
+zipkin_propagation = false
+# Setting this to true disables shared RPC spans.
+# Not disabling is the most common setting when using Zipkin elsewhere in your infrastructure.
+disable_shared_zipkin_spans = false
 
 #################################### External Image Storage ##############
 [external_image_storage]
+# Used for uploading images to public servers so they can be included in slack/email messages.
 # You can choose between (s3, webdav, gcs, azure_blob, local)
 provider =
 
 [external_image_storage.s3]
+endpoint =
+path_style_access =
 bucket_url =
 bucket =
 region =
@@ -575,6 +933,8 @@ public_url =
 key_file =
 bucket =
 path =
+enable_signed_urls = false
+signed_url_expiration =
 
 [external_image_storage.azure_blob]
 account_name =
@@ -585,9 +945,14 @@ container_name =
 # does not require any configuration
 
 [rendering]
-# Options to configure external image rendering server like https://github.com/grafana/grafana-image-renderer
+# Options to configure a remote HTTP image rendering service, e.g. using https://github.com/grafana/grafana-image-renderer.
+# URL to a remote HTTP image renderer service, e.g. http://localhost:8081/render, will enable Grafana to render panels and dashboards to PNG-images using HTTP requests to an external service.
 server_url =
+# If the remote HTTP image renderer service runs on a different server than the Grafana server you may have to configure this to a URL where Grafana is reachable, e.g. http://grafana.domain/.
 callback_url =
+# Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server,
+# which this setting can help protect against by only allowing a certain amount of concurrent requests.
+concurrent_render_request_limit = 30
 
 [panels]
 # here for to support old env variables, can remove after a few months
@@ -597,6 +962,131 @@ disable_sanitize_html = false
 [plugins]
 enable_alpha = false
 app_tls_skip_verify_insecure = false
+# Enter a comma-separated list of plugin identifiers to identify plugins to load even if they are unsigned. Plugins with modified signatures are never loaded.
+allow_loading_unsigned_plugins =
+# Enable or disable installing plugins directly from within Grafana.
+plugin_admin_enabled = true
+plugin_admin_external_manage_enabled = false
+plugin_catalog_url = https://grafana.com/grafana/plugins/
+
+#################################### Grafana Live ##########################################
+[live]
+# max_connections to Grafana Live WebSocket endpoint per Grafana server instance. See Grafana Live docs
+# if you are planning to make it higher than default 100 since this can require some OS and infrastructure
+# tuning. 0 disables Live, -1 means unlimited connections.
+max_connections = 100
+
+# allowed_origins is a comma-separated list of origins that can establish connection with Grafana Live.
+# If not set then origin will be matched over root_url. Supports wildcard symbol "*".
+allowed_origins =
+
+# engine defines an HA (high availability) engine to use for Grafana Live. By default no engine used - in
+# this case Live features work only on a single Grafana server.
+# Available options: "redis".
+# Setting ha_engine is an EXPERIMENTAL feature.
+ha_engine =
+
+# ha_engine_address sets a connection address for Live HA engine. Depending on engine type address format can differ.
+# For now we only support Redis connection address in "host:port" format.
+# This option is EXPERIMENTAL.
+ha_engine_address = "127.0.0.1:6379"
+
+#################################### Grafana Image Renderer Plugin ##########################
+[plugin.grafana-image-renderer]
+# Instruct headless browser instance to use a default timezone when not provided by Grafana, e.g. when rendering panel image of alert.
+# See ICU’s metaZones.txt (https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt) for a list of supported
+# timezone IDs. Fallbacks to TZ environment variable if not set.
+rendering_timezone =
+
+# Instruct headless browser instance to use a default language when not provided by Grafana, e.g. when rendering panel image of alert.
+# Please refer to the HTTP header Accept-Language to understand how to format this value, e.g. 'fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5'.
+rendering_language =
+
+# Instruct headless browser instance to use a default device scale factor when not provided by Grafana, e.g. when rendering panel image of alert.
+# Default is 1. Using a higher value will produce more detailed images (higher DPI), but will require more disk space to store an image.
+rendering_viewport_device_scale_factor =
+
+# Instruct headless browser instance whether to ignore HTTPS errors during navigation. Per default HTTPS errors are not ignored. Due to
+# the security risk it's not recommended to ignore HTTPS errors.
+rendering_ignore_https_errors =
+
+# Instruct headless browser instance whether to capture and log verbose information when rendering an image. Default is false and will
+# only capture and log error messages. When enabled, debug messages are captured and logged as well.
+# For the verbose information to be included in the Grafana server log you have to adjust the rendering log level to debug, configure
+# [log].filter = rendering:debug.
+rendering_verbose_logging =
+
+# Instruct headless browser instance whether to output its debug and error messages into running process of remote rendering service.
+# Default is false. This can be useful to enable (true) when troubleshooting.
+rendering_dumpio =
+
+# Additional arguments to pass to the headless browser instance. Default is --no-sandbox. The list of Chromium flags can be found
+# here (https://peter.sh/experiments/chromium-command-line-switches/). Multiple arguments is separated with comma-character.
+rendering_args =
+
+# You can configure the plugin to use a different browser binary instead of the pre-packaged version of Chromium.
+# Please note that this is not recommended, since you may encounter problems if the installed version of Chrome/Chromium is not
+# compatible with the plugin.
+rendering_chrome_bin =
+
+# Instruct how headless browser instances are created. Default is 'default' and will create a new browser instance on each request.
+# Mode 'clustered' will make sure that only a maximum of browsers/incognito pages can execute concurrently.
+# Mode 'reusable' will have one browser instance and will create a new incognito page on each request.
+rendering_mode =
+
+# When rendering_mode = clustered, you can instruct how many browsers or incognito pages can execute concurrently. Default is 'browser'
+# and will cluster using browser instances.
+# Mode 'context' will cluster using incognito pages.
+rendering_clustering_mode =
+# When rendering_mode = clustered, you can define the maximum number of browser instances/incognito pages that can execute concurrently. Default is '5'.
+rendering_clustering_max_concurrency =
+# When rendering_mode = clustered, you can specify the duration a rendering request can take before it will time out. Default is `30` seconds.
+rendering_clustering_timeout =
+
+# Limit the maximum viewport width, height and device scale factor that can be requested.
+rendering_viewport_max_width =
+rendering_viewport_max_height =
+rendering_viewport_max_device_scale_factor =
+
+# Change the listening host and port of the gRPC server. Default host is 127.0.0.1 and default port is 0 and will automatically assign
+# a port not in use.
+grpc_host =
+grpc_port =
 
 [enterprise]
 license_path =
+
+[feature_toggles]
+# enable features, separated by spaces
+enable =
+
+[date_formats]
+# For information on what formatting patterns that are supported https://momentjs.com/docs/#/displaying/
+
+# Default system date format used in time range picker and other places where full time is displayed
+full_date = YYYY-MM-DD HH:mm:ss
+
+# Used by graph and other places where we only show small intervals
+interval_second = HH:mm:ss
+interval_minute = HH:mm
+interval_hour = MM/DD HH:mm
+interval_day = MM/DD
+interval_month = YYYY-MM
+interval_year = YYYY
+
+# Experimental feature
+use_browser_locale = false
+
+# Default timezone for user preferences. Options are 'browser' for the browser local timezone or a timezone name from IANA Time Zone database, e.g. 'UTC' or 'Europe/Amsterdam' etc.
+default_timezone = browser
+
+[expressions]
+# Enable or disable the expressions functionality.
+enabled = true
+
+[geomap]
+# Set the JSON configuration for the default basemap
+default_baselayer_config =
+
+# Enable or disable loading other base map layers
+enable_custom_baselayers = true

--- a/roles/oauth-proxy/defaults/main.yml
+++ b/roles/oauth-proxy/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+oauthproxy_version: v7.2.0
+oauthproxy_home_dir: '/var/lib/oauthproxy'

--- a/roles/oauth-proxy/files/oauth2-proxy.service
+++ b/roles/oauth-proxy/files/oauth2-proxy.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=OAuth2 Proxy
+Documentation=https://github.com/oauth2-proxy/oauth2-proxy
+After=syslog.target network.target
+
+# https://github.com/oauth2-proxy/oauth2-proxy/blob/master/contrib/oauth2-proxy.service.example
+
+[Service]
+KillMode=process
+Restart=always
+
+User=oauthproxy
+Group=oauthproxy
+
+ExecStart=/usr/local/bin/oauth2-proxy --config=/etc/oauth2-proxy.cfg
+ExecReload=/bin/kill -HUP $MAINPID
+
+TimeoutStopSec=5s
+
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=full
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/oauth-proxy/handlers/main.yml
+++ b/roles/oauth-proxy/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: reload oauthproxy
+  systemd:
+    name: oauth2-proxy
+    state: reloaded
+    daemon_reload: yes
+
+- name: restart oauthproxy
+  systemd:
+    name: oauth2-proxy
+    state: restarted
+    daemon_reload: yes

--- a/roles/oauth-proxy/tasks/main.yml
+++ b/roles/oauth-proxy/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: create group
+  group:
+    name: oauthproxy
+    system: yes
+
+- name: create user
+  user:
+    name: oauthproxy
+    group: oauthproxy
+    system: yes
+    createhome: no
+    home: "{{ oauthproxy_home_dir }}"
+    shell: /sbin/nologin
+
+- name: create directories
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: oauthproxy
+    group: oauthproxy
+    mode: 0750
+  with_items:
+    - "{{ oauthproxy_home_dir }}"
+
+- name: determine installed oauth proxy version
+  shell: "oauth2-proxy --version | awk '{ print $2 }' || true"
+  register: oauthproxy_version_output
+
+- name: set oauthproxy_installed_version fact
+  set_fact: oauthproxy_installed_version="{{oauthproxy_version_output.stdout}}"
+
+- name: install oauth proxy
+  shell: |
+    mkdir -p /tmp/caddy-{{ oauthproxy_version }}
+    cd /tmp/caddy-{{ oauthproxy_version }}
+    curl -fsSLO https://github.com/oauth2-proxy/oauth2-proxy/releases/download/{{oauthproxy_version}}/oauth2-proxy-{{oauthproxy_version}}.linux-amd64.tar.gz
+    tar xvfz oauth2-proxy-{{oauthproxy_version}}.linux-amd64.tar.gz
+    install -m 0755 oauth2-proxy-{{oauthproxy_version}}.linux-amd64/oauth2-proxy /usr/local/bin/oauth2-proxy
+  args:
+    warn: false
+  when: oauthproxy_installed_version != oauthproxy_version
+  notify: restart oauthproxy
+
+- name: install oauth proxy config file
+  copy:
+    src: "{{ oauthproxy_config }}"
+    dest: /etc/oauth2-proxy.cfg
+    owner: oauthproxy
+    group: oauthproxy
+  notify: reload oauthproxy
+
+- name: install oauth2-proxy.service
+  copy:
+    src: oauth2-proxy.service
+    dest: /etc/systemd/system/oauth2-proxy.service
+  notify: restart oauthproxy
+
+- name: enable oauth2-proxy.service
+  systemd:
+    name: oauth2-proxy
+    enabled: true


### PR DESCRIPTION
Breaking change: now https://github.com/oauth2-proxy/oauth2-proxy is
used to handle authentication, which makes a few config updates
necessary. For example, you have to provide a config file for OAuth2
Proxy with your preferred provider configuration:

https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider

All endpoints (grafana/alertmanager/prometheus) are authenticated
through OAuth2 Proxy now, i.e. it's not necessary any longer to add
basic auth credentials to access prometheus and alertmanager too.

This commit also updates Grafana as well as its config to work with
OAuth2 Proxy and to update all defaults as found in version 8.3.2.