### PR TITLE
grafana/prometheus: use template instead of copy

### DIFF
--- a/roles/oauth-proxy/tasks/main.yml
+++ b/roles/oauth-proxy/tasks/main.yml
@@ -46,7 +46,7 @@
   notify: restart oauthproxy
 
 - name: install oauth proxy config file
-  copy:
+  template:
     src: "{{ oauthproxy_config }}"
     dest: /etc/oauth2-proxy.cfg
     owner: oauthproxy

--- a/roles/prometheus/tasks/alertmanager.yml
+++ b/roles/prometheus/tasks/alertmanager.yml
@@ -17,7 +17,7 @@
   notify: restart alertmanager
 
 - name: install alertmanager config
-  copy:
+  template:
     src: "{{ alertmanager_config }}"
     dest: /etc/prometheus/alertmanager.yml
     owner: prometheus


### PR DESCRIPTION
Use the template instead of the copy module for config files which could include secrets to support using variables in them to save secrets in an ansible vault.